### PR TITLE
dockerfiles: update python version to 3.8

### DIFF
--- a/.github/workflows/aut.yml
+++ b/.github/workflows/aut.yml
@@ -1,3 +1,4 @@
+SKIP  ubi7-py35
 jobs:
   build:
     name: ${{ matrix.pretty_name }}
@@ -287,12 +288,6 @@ jobs:
           pretty_name: ubi7-py35 pip-latest 2.11.5
           product: ansible-core
           version: 2.11.5
-        - build_args: ''
-          dockerfile: ubi7-py35
-          pre: pip-latest
-          pretty_name: ubi7-py35 pip-latest 2.12.0b1
-          product: ansible-core
-          version: 2.12.0b1
         - build_args: ''
           dockerfile: ubi8
           pre: pip

--- a/.github/workflows/aut.yml
+++ b/.github/workflows/aut.yml
@@ -1,4 +1,3 @@
-SKIP  ubi7-py35
 jobs:
   build:
     name: ${{ matrix.pretty_name }}

--- a/build-matrix.py
+++ b/build-matrix.py
@@ -101,7 +101,6 @@ def fill_matrix(job, data, entries):
 
                     for version in data[product]:
                         if version > '2.11' and os_env == 'ubi7-py35':
-                            print("SKIP ", os_env)
                             continue
                         pre_values = []  # Used in pretty_name
                         matrix_entry = {

--- a/build-matrix.py
+++ b/build-matrix.py
@@ -100,6 +100,9 @@ def fill_matrix(job, data, entries):
                         continue
 
                     for version in data[product]:
+                        if version > '2.11' and os_env == 'ubi7-py35':
+                            print("SKIP ", os_env)
+                            continue
                         pre_values = []  # Used in pretty_name
                         matrix_entry = {
                             'dockerfile': os_env,

--- a/dockerfiles/centos7
+++ b/dockerfiles/centos7
@@ -2,8 +2,12 @@ FROM centos:7
 
 RUN yum -y update && \
   yum -y install epel-release && \
-  yum -y install python-pip wget which && \
+  yum install -y centos-release-scl-rh && \
+  yum install -y rh-python38-python rh-python38-python-pip wget which && \
   yum clean all
+
+ENV PATH=/opt/rh/rh-python38/root/usr/local/bin:/opt/rh/rh-python38/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV LD_LIBRARY_PATH=/opt/rh/rh-python38/root/usr/lib64
 
 COPY . /opt
 

--- a/dockerfiles/centos8
+++ b/dockerfiles/centos8
@@ -1,7 +1,8 @@
 FROM centos:8
 
 RUN yum -y update && \
-  yum -y install python3-pip wget which && \
+  yum -y module enable python38 && \
+  yum -y install python38-pip wget which && \
   yum clean all
 
 COPY . /opt

--- a/dockerfiles/ubi7
+++ b/dockerfiles/ubi7
@@ -2,10 +2,13 @@ FROM registry.access.redhat.com/ubi7/ubi
 
 RUN \
   yum update -y && \
-  yum install -y https://da.gd/epel7?.rpm && \
-  yum install -y http://mirror.centos.org/centos-7/7/os/x86_64/Packages/python-virtualenv-15.1.0-4.el7_7.noarch.rpm \
-    procps-ng python-pip wget which && \
+  yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+  http://mirror.centos.org/centos-7/7/os/x86_64/Packages/python-virtualenv-15.1.0-4.el7_7.noarch.rpm \
+  rh-python38-python rh-python38-python-pip procps-ng wget which && \
   yum clean all
+
+ENV PATH=/opt/rh/rh-python38/root/usr/local/bin:/opt/rh/rh-python38/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV LD_LIBRARY_PATH=/opt/rh/rh-python38/root/usr/lib64
 
 COPY . /opt
 

--- a/dockerfiles/ubi8
+++ b/dockerfiles/ubi8
@@ -2,7 +2,8 @@ FROM registry.access.redhat.com/ubi8/ubi
 
 RUN \
   yum update -y && \
-  yum install -y procps-ng python3-pip wget && \
+  yum -y module enable python38 && \
+  yum -y install procps-ng python38-pip wget && \
   yum clean all
 
 COPY . /opt

--- a/dockerfiles/ubuntu1804
+++ b/dockerfiles/ubuntu1804
@@ -2,8 +2,10 @@ FROM ubuntu:18.04
 
 RUN apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y install python3-pip wget && \
+  apt-get -y install python3.8 python3-pip wget && \
   apt-get clean
+
+RUN ln /usr/bin/python3.8 /usr/bin/python3 -sf
 
 COPY . /opt
 

--- a/pre/pip-latest.sh
+++ b/pre/pip-latest.sh
@@ -16,4 +16,10 @@ EOF
 )"
 
 $PIP install --upgrade "$PIPVER"
+
+# When upgrading pip from SCL the pip binary path
+# change so we need to reload the path in the PIP
+# variable.
+source pip-common.sh
+
 $PIP install $PRODUCT==$VERSION


### PR DESCRIPTION
Since 2.12 requires py3.8 minimum and older versions back to 2.9
also support 3.8 then use that version.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>