### PR TITLE
Use regex to not test ubi7-py35 fro ansible 2.12+

### DIFF
--- a/build-matrix.py
+++ b/build-matrix.py
@@ -100,8 +100,6 @@ def fill_matrix(job, data, entries):
                         continue
 
                     for version in data[product]:
-                        if version > '2.11' and os_env == 'ubi7-py35':
-                            continue
                         pre_values = []  # Used in pretty_name
                         matrix_entry = {
                             'dockerfile': os_env,

--- a/matrix.yml
+++ b/matrix.yml
@@ -50,6 +50,7 @@ dockerfiles:
           - rc
   ubi7-py35:
     - pip-latest:
+        version_re: '^2\.(?:9|10|11)'
   ubi8:
     - pip:
     - tar:


### PR DESCRIPTION
@relrod found a much cleaner way to exclude ubi7-py35 for ansible 2.12+ testing.  

From [comment](https://github.com/ansible/aut/commit/166992ae5fed8e403d94d290c14a7a1260fb6337#r57143825) on the recent AUT changes to support 2.12 testing.  