### PR TITLE
Use markupsafe 2.1 with old version of pip

### DIFF
--- a/pre/pip-common.sh
+++ b/pre/pip-common.sh
@@ -29,7 +29,7 @@ pip_major = int(pip.__version__.split('.')[0])
 if pip_major < 9:
     print("pyyaml cryptography>=2.5,<3.4 jinja2<3 markupsafe<2 packaging<21")
 elif pip_major < 19:
-    print("pyyaml cryptography>=2.5,<3.4 jinja2 markupsafe")
+    print("pyyaml cryptography>=2.5,<3.4 jinja2 markupsafe<2.1")
 else:
     print("pyyaml cryptography jinja2 markupsafe")
 EOF


### PR DESCRIPTION
This will clear up AUT the failures against Ubuntu 18 that started ~ 6 days ago.  Those jobs failed with the following error:

```
    ModuleNotFoundError: No module named 'markupsafe'
```

Example job: https://github.com/ansible/aut/runs/5310704821?check_suite_focus=true